### PR TITLE
Minor Meson fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,7 @@ ksim_files = files(
 
 shared_library('ksim-stub',
 	ksim_files, disasm_files,
-	c_args : [ '-fvisibility=hidden', '-Wall', '-march=native', '-mrtm', '-D_GNU_SOURCE' ],
+	c_args : [ '-fvisibility=hidden', '-march=native', '-mrtm', '-D_GNU_SOURCE' ],
 	dependencies : [ libdrm, libdrm_intel, libpng16, opcodes ],
 	link_args : [ '-ldl', '-pthread', '-lm' ],
 	name_prefix : '',
@@ -55,13 +55,13 @@ shared_library('ksim-stub',
 
 executable('cs-runner',
 	files('test/cs-runner.c'),
-	c_args : [ '-fvisibility=hidden', '-Wall', '-march=native', '-mrtm' ],
+	c_args : [ '-fvisibility=hidden', '-march=native', '-mrtm' ],
 	dependencies : [ libdrm_intel ],
 	link_args : [ '-lm' ],
 	install : false)
 
 executable('test-avx-builder',
 	files('avx-builder.c'),
-	c_args : [ '-Wall', '-march=native', '-mrtm',  '-DTEST_AVX_BUILDER' ],
+	c_args : [ '-march=native', '-mrtm',  '-DTEST_AVX_BUILDER' ],
 	dependencies : [ opcodes ],
 	install : false)

--- a/meson.build
+++ b/meson.build
@@ -63,8 +63,10 @@ executable('cs-runner',
 	dependencies : [ libdrm_intel, mathlib ],
 	install : false)
 
-executable('test-avx-builder',
+avxbuilder_test = executable('test-avx-builder',
 	files('avx-builder.c'),
 	c_args : [ '-march=native', '-mrtm',  '-DTEST_AVX_BUILDER' ],
 	dependencies : [ opcodes ],
 	install : false)
+
+test('avx-builder', avxbuilder_test)

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,9 @@ libdrm = dependency('libdrm')
 libdrm_intel = dependency('libdrm_intel')
 libpng16 = dependency('libpng16')
 threads = dependency('threads')
+# This is the portable way of using mathlib, it does
+# not exist on all platforms.
+mathlib = c.find_library('m', required : false)
 
 conf = configuration_data()
 conf.set('prefix', get_option('prefix'))
@@ -49,16 +52,15 @@ ksim_files = files(
 shared_library('ksim-stub',
 	ksim_files, disasm_files,
 	c_args : [ '-fvisibility=hidden', '-march=native', '-mrtm', '-D_GNU_SOURCE' ],
-	dependencies : [ libdrm, libdrm_intel, libpng16, opcodes, threads ],
-	link_args : [ '-ldl', '-lm' ],
+	dependencies : [ libdrm, libdrm_intel, libpng16, opcodes, threads, mathlib ],
+	link_args : [ '-ldl' ],
 	name_prefix : '',
 	install : true)
 
 executable('cs-runner',
 	files('test/cs-runner.c'),
 	c_args : [ '-fvisibility=hidden', '-march=native', '-mrtm' ],
-	dependencies : [ libdrm_intel ],
-	link_args : [ '-lm' ],
+	dependencies : [ libdrm_intel, mathlib ],
 	install : false)
 
 executable('test-avx-builder',

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,7 @@ opcodes = c.find_library('opcodes')
 libdrm = dependency('libdrm')
 libdrm_intel = dependency('libdrm_intel')
 libpng16 = dependency('libpng16')
+threads = dependency('threads')
 
 conf = configuration_data()
 conf.set('prefix', get_option('prefix'))
@@ -48,8 +49,8 @@ ksim_files = files(
 shared_library('ksim-stub',
 	ksim_files, disasm_files,
 	c_args : [ '-fvisibility=hidden', '-march=native', '-mrtm', '-D_GNU_SOURCE' ],
-	dependencies : [ libdrm, libdrm_intel, libpng16, opcodes ],
-	link_args : [ '-ldl', '-pthread', '-lm' ],
+	dependencies : [ libdrm, libdrm_intel, libpng16, opcodes, threads ],
+	link_args : [ '-ldl', '-lm' ],
 	name_prefix : '',
 	install : true)
 


### PR DESCRIPTION
Here are a few cleanups to the Meson build definition. Each commit is standalone and should be easy to understand. Based on the code, avxbuilder is a test so created the test setup so it can be run with `ninja test`.

I could not verify that compilation still works because it fails on my system GCC with a weird architecture error.